### PR TITLE
Fix the judgement of torchvision.__version__

### DIFF
--- a/util/misc.py
+++ b/util/misc.py
@@ -27,7 +27,7 @@ from torch import Tensor
 
 # needed due to empty tensor bug in pytorch and torchvision 0.5
 import torchvision
-if float(torchvision.__version__[:3]) < 0.5:
+if int(torchvision.__version__[2:-2]) < 5:
     import math
     from torchvision.ops.misc import _NewEmptyTensorOp
     def _check_size_scale_factor(dim, size, scale_factor):
@@ -54,7 +54,7 @@ if float(torchvision.__version__[:3]) < 0.5:
         return [
             int(math.floor(input.size(i + 2) * scale_factors[i])) for i in range(dim)
         ]
-elif float(torchvision.__version__[:3]) < 0.7:
+elif int(torchvision.__version__[2:-2]) < 7:
     from torchvision.ops import _new_empty_tensor
     from torchvision.ops.misc import _output_size
 


### PR DESCRIPTION
Hi, thank you for your excellent work!

I found when torchvision.__version__ >= 0.10.0, the original code would be False, which is unexpected. 

I think we should only consider the intermediate version number of that.