### PR TITLE
fix linear projection for bounding box binary classification

### DIFF
--- a/models/deformable_detr.py
+++ b/models/deformable_detr.py
@@ -51,7 +51,7 @@ class DeformableDETR(nn.Module):
         self.num_queries = num_queries
         self.transformer = transformer
         hidden_dim = transformer.d_model
-        self.class_embed = nn.Linear(hidden_dim, num_classes)
+        self.class_embed = nn.Linear(hidden_dim, 2)
         self.bbox_embed = MLP(hidden_dim, hidden_dim, 4, 3)
         self.num_feature_levels = num_feature_levels
         if not two_stage:


### PR DESCRIPTION
The paper says:

> The detection head is of a 3-layer FFN for bounding box regression, and a linear projection for bounding box binary classification (i.e., foreground and background)

Doesn't that mean we should only have 2 outputs in `class_embed`? (later used in [here](https://github.com/fundamentalvision/Deformable-DETR/blob/11169a60c33333af00a4849f1808023eba96a931/models/deformable_transformer.py#L161))

EDIT: after further investigation it seems that my confusion comes from [this line ](https://github.com/fundamentalvision/Deformable-DETR/blob/11169a60c33333af00a4849f1808023eba96a931/models/deformable_transformer.py#L165). Why do we pick the best scoring bounding boxes based on the first class?