### PR TITLE
fix Top K proposals in two_stage

### DIFF
--- a/models/deformable_transformer.py
+++ b/models/deformable_transformer.py
@@ -162,7 +162,7 @@ class DeformableTransformer(nn.Module):
             enc_outputs_coord_unact = self.decoder.bbox_embed[self.decoder.num_layers](output_memory) + output_proposals
 
             topk = self.two_stage_num_proposals
-            topk_proposals = torch.topk(enc_outputs_class[..., 0], topk, dim=1)[1]
+            topk_proposals = torch.topk(enc_outputs_class.max(-1)[0], topk, dim=1)[1]
             topk_coords_unact = torch.gather(enc_outputs_coord_unact, 1, topk_proposals.unsqueeze(-1).repeat(1, 1, 4))
             topk_coords_unact = topk_coords_unact.detach()
             reference_points = topk_coords_unact.sigmoid()


### PR DESCRIPTION
Reference:
https://github.com/IDEA-Research/DINO/blob/main/models/dino/deformable_transformer.py#L342

Related to https://github.com/fundamentalvision/Deformable-DETR/issues/79

It's not reasonable to judge a foreground only by the score in the first category (class 0).